### PR TITLE
Golang Tutorial Snake

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -83,6 +83,9 @@
                   <li class="nav-item">
                     <a class="nav-link" href="/zero-to-snake-windows-chocolatey.html">Snake Tutorial (js) - Windows (chocolatey)</a>
                   </li>
+                  <li class="nav-item">
+                    <a class="nav-link" href="/zero-to-go-snake.html">Snake Tutorial (go)</a>
+                  </li>
                   <li class="nav-header p-t-15 font-weight-600">
                     Development
                   </li>
@@ -91,7 +94,7 @@
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="/snake-customization.html">Customizing Your Snake</a>
-                  </li>                  
+                  </li>
                   <li class="nav-item">
                     <a class="nav-link" href="https://github.com/battlesnakeio/community/blob/master/starter-snakes.md" target="_blank">Starter Snakes</a>
                   </li>
@@ -103,7 +106,7 @@
                   </li>
                   <li class="nav-item">
                     <a class="nav-link" href="/contribute.html">Get Involved</a>
-                  </li>               
+                  </li>
                   <li class="nav-header p-t-15 font-weight-600">
                     Tournament
                   </li>

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -1,0 +1,119 @@
+---
+layout: card
+title: Zero to Snake (with Go)
+categories: [doc]
+---
+
+This document will allow you to start developing a Battlesnake snake AI using Golang programming language.
+
+## Step 1 - Get stated with Gitpod
+
+### Step 1.1 - Create a GitHub account
+
+GitHub is a platform for storing and managing source code and uses a version control system called Git.
+
+Your snake's source code will be stored on GitHub. It will be publicly available and will stay around for you to use at future events.
+
+Go to https://github.com/join to create an account, and choose the free option.
+
+### Step 1.2 - Fork the starter snake repository
+
+Forking a GitHub repo lets you copy source code from an open source project to your own GitHub repo.
+
+There is a repo that contains example Golang code to run a very basic battle snake, and you can fork it here: https://github.com/battlesnakeio/starter-snake-go/fork
+
+### Step 1.3 - Start Gitpod
+
+Gitpod will set up your development environment, and host your application. You just need to tell it which GitHub repo to connect to.
+
+Put your github username into the following url instead of `<your-username>`, and go to it.
+
+gitpod.io/#github.com/`<your-username>`/starter-snake-go
+
+You'll need to be logged into GitHub with the same username, and give it permission to your account.
+
+### Step 1.4 - Start your snake
+
+Once you're in Gitpod, you can run the starter snake. Type `make run` in the terminal console and hit enter.
+
+It will tell you that an application is running on port 9000, and show a button that says `Open Browser`. Hit that button and copy the URL that it goes to. You'll need that later; it is the URL of snake.
+
+# Step 2 - Create a battlesnake game
+
+### Step 2.1 - Add your snake
+
+Now that the starter snake is running, you can put it in the ring!
+
+Go to play.battlesnake.io, go to `My Snakes` (log in with your GitHub), and `Add a Snake`. Choose your name, and use the URL from step 1.4.
+
+### 2.2 - Create a game
+
+on play.battlesnake.io, go to `Create a game`. On the field `Add snakes to the pit`, search for the snake name you just made and click `Add`. You can add other snakes too.
+
+click `Create Game` and it will go into the player. At the bottom of the player, hit `play`. Your snake should go straight to the bottom, since that's all the starter snake knows how to do.
+
+# Step 3 - Improve your snake
+
+Now you can make your AI snake do something more intelligent!
+
+### Step 3.1 - Modify some code
+
+Look around the code to see what's going on, or get someone to help explain it. We'll go through a simple example of what you can change, but the rest is up to you.
+
+Go back to your Gitpod workspace (or find it again at gitpod.io), and open the `routes.go` file. It handles each of the requests that the gameplay server can initiate.
+
+The most important one is `Move()`, and right now it always returns a response with `Move: "down"`. We're going to change it to something slightly more complex:
+
+```
+func Move(res http.ResponseWriter, req *http.Request) {
+	decoded := api.SnakeRequest{}
+	err := api.DecodeSnakeRequest(req, &decoded)
+	if err != nil {
+		log.Printf("Bad move request: %v", err)
+	}
+	dump(decoded)
+
+	moveDirection := "left"
+
+	if decoded.You.Body[0].X < 3 {
+		moveDirection = "up"
+	}
+	if decoded.You.Body[0].Y < 3 {
+		moveDirection = "right"
+	}
+	if decoded.You.Body[0].X > 8 {
+		moveDirection = "down"
+	}
+	if decoded.You.Body[0].Y > 8 && decoded.You.Body[0].X > 3 {
+		moveDirection = "left"
+	}
+
+	respond(res, api.MoveResponse{
+		Move: moveDirection,
+	})
+}
+```
+
+Step 3.2 - See it in action!
+
+In the terminal, cancel the last `make run` command by hitting ctrl-c. Then start `make run` again. Now it will be running the new code.
+
+In play.battlesnake.io, hit the back button to go back to `Create Game` and run it with your snake in the ring again. Now it should be doing something slightly more interesting.
+
+Step 3.3 - Save your changes
+
+To keep your changes on your GitHub repo, you'll need to commit and push the changes.
+
+Git can be a bit complex to learn at first, but we'll do a simple example. Run these in a Gitpod terminal (make sure it's not a terminal that is already running your snake):
+```
+git add .
+git commit -m "Make the snake spin"
+git push
+```
+(You can make your own commit message in the double quotes)
+
+You will need to give additional permissions to Gitpod so that it can write to your repo.
+
+# Step 4 - Get competitive
+
+Keep repeating step 3 with your own changes until you have the best snake!

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -81,11 +81,8 @@ func Move(res http.ResponseWriter, req *http.Request) {
 	if decoded.You.Body[0].Y < 3 {
 		moveDirection = "right"
 	}
-	if decoded.You.Body[0].X > 8 {
+	if decoded.You.Body[0].X > 8 && decoded.You.Body[0].Y < 8 {
 		moveDirection = "down"
-	}
-	if decoded.You.Body[0].Y > 8 && decoded.You.Body[0].X > 3 {
-		moveDirection = "left"
 	}
 
 	respond(res, api.MoveResponse{

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -6,7 +6,11 @@ categories: [doc]
 
 This document will allow you to start developing a Battlesnake snake AI using Golang programming language.
 
+---
+
 ## Step 1 - Get stated with Gitpod
+
+---
 
 ### Step 1.1 - Create a GitHub account
 
@@ -16,11 +20,15 @@ Your snake's source code will be stored on GitHub. It will be publicly available
 
 Go to https://github.com/join to create an account, and choose the free option.
 
+---
+
 ### Step 1.2 - Fork the starter snake repository
 
 Forking a GitHub repo lets you copy source code from an open source project to your own GitHub repo.
 
 There is a repo that contains example Golang code to run a very basic battle snake, and you can fork it here: https://github.com/battlesnakeio/starter-snake-go/fork
+
+---
 
 ### Step 1.3 - Start Gitpod
 
@@ -32,13 +40,19 @@ gitpod.io/#github.com/`<your-username>`/starter-snake-go
 
 You'll need to be logged into GitHub with the same username, and give it permission to your account.
 
+---
+
 ### Step 1.4 - Start your snake
 
 Once you're in Gitpod, you can run the starter snake. Type `make run` in the terminal console and hit enter.
 
 It will tell you that an application is running on port 9000, and show a button that says `Open Browser`. Hit that button and copy the URL that it goes to. You'll need that later; it is the URL of snake.
 
+---
+
 # Step 2 - Create a battlesnake game
+
+---
 
 ### Step 2.1 - Add your snake
 
@@ -46,15 +60,21 @@ Now that the starter snake is running, you can put it in the ring!
 
 Go to play.battlesnake.io, go to `My Snakes` (log in with your GitHub), and `Add a Snake`. Choose your name, and use the URL from step 1.4.
 
+---
+
 ### Step 2.2 - Create a game
 
 on play.battlesnake.io, go to `Create a game`. On the field `Add snakes to the pit`, search for the snake name you just made and click `Add`. You can add other snakes too.
 
 click `Create Game` and it will go into the player. At the bottom of the player, hit `play`. Your snake should go straight to the bottom, since that's all the starter snake knows how to do.
 
+---
+
 # Step 3 - Improve your snake
 
 Now you can make your AI snake do something more intelligent!
+
+---
 
 ### Step 3.1 - Modify some code
 
@@ -91,11 +111,15 @@ func Move(res http.ResponseWriter, req *http.Request) {
 }
 ```
 
+---
+
 ### Step 3.2 - See it in action!
 
 In the terminal, cancel the last `make run` command by hitting ctrl-c. Then start `make run` again. Now it will be running the new code.
 
 In play.battlesnake.io, hit the back button to go back to `Create Game` and run it with your snake in the ring again. Now it should be doing something slightly more interesting.
+
+---
 
 ### Step 3.3 - Save your changes
 
@@ -110,6 +134,8 @@ git push
 (You can make your own commit message in the double quotes)
 
 You will need to give additional permissions to Gitpod so that it can write to your repo. Then run `git push` again.
+
+---
 
 # Step 4 - Get competitive
 

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -142,4 +142,4 @@ You will need to give additional permissions to Gitpod so that it can write to y
 
 Keep repeating step 3 with your own changes until you have the best snake!
 
-When a tournament starts, make sure your Gitpod workspace is running. It will timeout after 30 minutes (10 minutes if you close the window), and you will have to start it again. If it stops when a game is started, your snake will not respond and lose immediately!
+When a tournament starts, make sure your Gitpod workspace is running. It will timeout after 30 minutes of inactivity (10 minutes if you close the window), and you will have to start it again. If it stops when a game is started, your snake will not respond and lose immediately!

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -141,3 +141,5 @@ You will need to give additional permissions to Gitpod so that it can write to y
 # Step 4 - Get competitive
 
 Keep repeating step 3 with your own changes until you have the best snake!
+
+When a tournament starts, make sure your Gitpod workspace is running. It will timeout after 30 minutes (10 minutes if you close the window), and you will have to start it again. If it stops when a game is started, your snake will not respond and lose immediately!

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -105,6 +105,9 @@ func Move(res http.ResponseWriter, req *http.Request) {
 	if yourHeadCoord.X > 8 && yourHeadCoord.Y < 8 {
 		moveDirection = "down"
 	}
+	if decoded.Turn > 100 {
+		moveDirection = "left"
+	}
 
 	respond(res, api.MoveResponse{
 		Move: moveDirection,

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -46,7 +46,7 @@ Now that the starter snake is running, you can put it in the ring!
 
 Go to play.battlesnake.io, go to `My Snakes` (log in with your GitHub), and `Add a Snake`. Choose your name, and use the URL from step 1.4.
 
-### 2.2 - Create a game
+### Step 2.2 - Create a game
 
 on play.battlesnake.io, go to `Create a game`. On the field `Add snakes to the pit`, search for the snake name you just made and click `Add`. You can add other snakes too.
 
@@ -91,13 +91,13 @@ func Move(res http.ResponseWriter, req *http.Request) {
 }
 ```
 
-Step 3.2 - See it in action!
+### Step 3.2 - See it in action!
 
 In the terminal, cancel the last `make run` command by hitting ctrl-c. Then start `make run` again. Now it will be running the new code.
 
 In play.battlesnake.io, hit the back button to go back to `Create Game` and run it with your snake in the ring again. Now it should be doing something slightly more interesting.
 
-Step 3.3 - Save your changes
+### Step 3.3 - Save your changes
 
 To keep your changes on your GitHub repo, you'll need to commit and push the changes.
 

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -94,14 +94,15 @@ func Move(res http.ResponseWriter, req *http.Request) {
 	dump(decoded)
 
 	moveDirection := "left"
+	yourHeadCoord := decoded.You.Body[0]
 
-	if decoded.You.Body[0].X < 3 {
+	if yourHeadCoord.X < 3 {
 		moveDirection = "up"
 	}
-	if decoded.You.Body[0].Y < 3 {
+	if yourHeadCoord.Y < 3 {
 		moveDirection = "right"
 	}
-	if decoded.You.Body[0].X > 8 && decoded.You.Body[0].Y < 8 {
+	if yourHeadCoord.X > 8 && yourHeadCoord.Y < 8 {
 		moveDirection = "down"
 	}
 

--- a/docs/zero-to-go-snake.md
+++ b/docs/zero-to-go-snake.md
@@ -109,7 +109,7 @@ git push
 ```
 (You can make your own commit message in the double quotes)
 
-You will need to give additional permissions to Gitpod so that it can write to your repo.
+You will need to give additional permissions to Gitpod so that it can write to your repo. Then run `git push` again.
 
 # Step 4 - Get competitive
 


### PR DESCRIPTION
A better README on top of the changes to https://github.com/battlesnakeio/starter-snake-go/pull/12

Requires the .gitpod.yml changes in that PR

Solves https://github.com/battlesnakeio/roadmap/issues/267

Also, should the starter snake repo READMEs just point to a tutorial doc page? Seems like that would make sense and avoid the duplication.


![Screen Shot 2019-08-27 at 1 31 35 PM](https://user-images.githubusercontent.com/38707096/63802210-4e5cc980-c8cf-11e9-82a8-3af762d0c255.png)

![Screen Shot 2019-08-27 at 1 31 56 PM](https://user-images.githubusercontent.com/38707096/63802216-5157ba00-c8cf-11e9-9b17-522310ffa5e5.png)
![Screen Shot 2019-08-27 at 1 33 20 PM](https://user-images.githubusercontent.com/38707096/63802220-54eb4100-c8cf-11e9-9002-dee1734bcf78.png)
![Screen Shot 2019-08-27 at 1 33 27 PM](https://user-images.githubusercontent.com/38707096/63802222-561c6e00-c8cf-11e9-8941-8707a6b5a208.png)
![Screen Shot 2019-08-27 at 1 33 33 PM](https://user-images.githubusercontent.com/38707096/63802226-57e63180-c8cf-11e9-9983-47163dea759d.png)
