### PR TITLE
Add the Ruby Starter Snake to the official list.

### DIFF
--- a/docs/pages/starter-snakes.md
+++ b/docs/pages/starter-snakes.md
@@ -13,6 +13,7 @@ The Battlesnake community provides a selection of basic Starter Snake projects t
 * [Java Starter Snake](https://github.com/battlesnakeio/starter-snake-java)
 * [JavaScript (Node) Starter Snake](https://github.com/battlesnakeio/starter-snake-node)
 * [Python Starter Snake](https://github.com/battlesnakeio/starter-snake-python)
+* [Ruby Starter Snake](https://github.com/battlesnakeio/starter-snake-ruby)
 
 These Starter Snake projects are built and maintained by the Battlesnake team. We do our best to keep these functional and up to date with the latest game features and API changes.
 


### PR DESCRIPTION
The Ruby Starter Snake is on the official Battlesnake Github, and appears to be up to date, but it wasn't listed under Official Starter Snakes.

Please feel free to reject this if it's not right to add it to the official list. 👍 